### PR TITLE
コメント一覧機能(ツイート詳細画面時)

### DIFF
--- a/src/apis/tweets.js
+++ b/src/apis/tweets.js
@@ -1,4 +1,4 @@
-import { tweets } from "../urls";
+import { comments, tweets } from "../urls";
 import {
   baseAxiosWithAuthHeaders,
   fetchingActionTypes,
@@ -45,6 +45,23 @@ export const fetchTweetsShow = (id) => {
       params: {
         id: id,
       },
+    })
+    .then((res) => ({
+      type: fetchingActionTypes.FETCH_SUCCESS,
+      data: res.data,
+    }))
+    .catch((e) => ({
+      type: e.isLogin
+        ? fetchingActionTypes.FETCH_FAILED
+        : fetchingActionTypes.AUTH_FAILED,
+      errors: e,
+    }));
+};
+
+export const fetchTweetsShowComments = (id) => {
+  return baseAxiosWithAuthHeaders
+    .get(`${tweets}/${id}/${comments}`, {
+      id: id,
     })
     .then((res) => ({
       type: fetchingActionTypes.FETCH_SUCCESS,

--- a/src/components/templates/ShowTweetLayout.jsx
+++ b/src/components/templates/ShowTweetLayout.jsx
@@ -7,6 +7,7 @@ export const ShowTweetLayout = (props) => {
     loading,
     bodyContents,
     commentForm,
+    comments,
     sideContentsHeader,
     sideContentsBody,
   } = props;
@@ -53,6 +54,7 @@ export const ShowTweetLayout = (props) => {
             <div className="flex px-4 pt-3 pb-1 border-b border-gray-500">
               {commentForm}
             </div>
+            <div>{comments}</div>
           </div>
           <div
             className={`

--- a/src/hooks/tweets.js
+++ b/src/hooks/tweets.js
@@ -50,3 +50,18 @@ export const useTweetsShow = (initialState) => {
     },
   };
 };
+
+export const useTweetCommentsIndex = (initialState) => {
+  const [fetchState, dispatch] = useReducer(fetchReducer, initialState);
+
+  const failedCall = useAuthFailedCall();
+
+  return {
+    fetchTweetCommentsState: fetchState,
+    fetchTweetCommentsDispatch: dispatch,
+    fetchTweetCommentsCallback: {
+      success: null,
+      authFiled: failedCall,
+    },
+  };
+};


### PR DESCRIPTION
## 課題のリンク

* [コメント一覧機能(ツイート詳細画面時)](https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#:~:text=%E3%81%A7%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B-,%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E4%B8%80%E8%A6%A7%E6%A9%9F%E8%83%BD,-rails)

## やったこと

* コメント一覧機能(ツイート詳細画面時)の実装


## 動作確認方法

* コメント一覧機能(ツイート詳細画面)のSS
![リプライ](https://github.com/K-Akira928/twitter_rails_api/assets/134822923/f8457d23-1409-496d-b428-2c556628287d)

## その他

* 次のタスクにある [コメント削除API](https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#:~:text=%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B-,rails(%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E5%89%8A%E9%99%A4API),-%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E3%81%AE%E5%89%8A%E9%99%A4) ですが、コメントにコメントできるようにする実装の関係上、既にコメント削除(本質的にはツイート削除)が機能する状態になっています。よって、このタスクでLGTMを頂いた場合コメント削除もLGTM頂いたと認識してもよろしいでしょうか。  